### PR TITLE
Create config class, to handle session and parameters to filesystem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.5
   - nightly
 install:
-  - pip install flake8 flake8-import-order
+  - pip install flake8 flake8-import-order pyyaml
 script:
   - flake8 .
   - nosetests

--- a/photocollage/config.py
+++ b/photocollage/config.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Joël BOURGAULT
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import gettext
+import logging
+import os
+import time
+
+import yaml
+
+from photocollage import APP_NAME
+
+# constant definition
+FILE_OPEN_TIME_STEP = 0.32414  #: some random value between opening trials
+FILE_OPEN_TIMEOUT = 2  #: in seconds
+
+# logging configuration
+top_logger = logging.getLogger(__name__)
+
+gettext.textdomain(APP_NAME)
+_ = gettext.gettext
+_n = gettext.ngettext
+
+
+# classes definition
+class OptionsLoadError(IOError):
+    pass
+
+
+class OptionsStoreError(IOError):
+    pass
+
+
+class OptionsManager(object):
+    """Handles options, as Python attributes, and load/store to filesystem.
+
+    ..Note::
+        This class does not write to filesystem. This shall be provided by
+        sub-classes. In this case, take care to extend the list of
+        protected names (those that will not be stored on filesystem),
+        :py:attribute:_PROTECTED_NAMES.
+
+    >>> opts = OptionsManager()
+    >>> opts.a = 5
+    >>> opts
+    <OptionsManager object: {'a': 5}>
+    >>> opts.b = 8
+    >>> opts
+    <OptionsManager object: {'a': 5, 'b': 8}>
+
+    """
+    _PROTECTED_NAMES = ('setdefault', 'update')
+
+    def __init__(self, *args, **kwargs):
+        self._logger = top_logger.getChild(__name__)
+        self._data = dict(*args, **kwargs)
+
+    def __getattribute__(self, item):
+        if not item.startswith('_') and item not in self._PROTECTED_NAMES:
+            return self._data[item]
+        else:
+            return super(OptionsManager, self).__getattribute__(item)
+
+    def __setattr__(self, key, value):
+        if not key.startswith('_') and key not in self._PROTECTED_NAMES:
+            self._data[key] = value
+        else:
+            super(OptionsManager, self).__setattr__(key, value)
+
+    def setdefault(self, **kwargs):
+        """Set values if not already existing
+
+        >>> opts = OptionsManager()
+        >>> opts.a = 1
+        >>> opts.setdefault(a=0, b=2, c=3)
+        >>> opts
+        <OptionsManager object: {'a': 1, 'b': 2, 'c': 3}>
+
+        """
+        for k, v in kwargs.items():
+            self._data.setdefault(k, v)
+
+    def update(self, **kwargs):
+        """Update or set values
+
+        >>> opts = OptionsManager()
+        >>> opts.a = 1
+        >>> opts.update(a=0, b=2, c=3)
+        >>> opts
+        <OptionsManager object: {'a': 0, 'b': 2, 'c': 3}>
+
+        """
+        self._data.update(kwargs)
+
+    def __repr__(self):
+        return "<%s object: %s>" % (self.__class__.__name__,
+                                    self._data)
+
+
+class YamlOptionsManager(OptionsManager):
+    """Handles options, based on a YAML file.
+
+    Takes care of writing configuration to filesystem at exit.
+
+    >>> opts_fn = "../tests/opts.yml"
+    >>> if os.path.exists(opts_fn):
+    ...     os.remove(opts_fn)
+    ...
+    >>> opts = YamlOptionsManager(opts_fn)
+    >>> print(opts)
+    <YamlOptionsManager object: {}>
+    >>> opts.configuration = dict(last_visited_directory="/home/adrien/photos")
+    >>> opts.store()
+    >>> print(open(opts_fn).read())
+    configuration: {last_visited_directory: /home/adrien/photos}
+    <BLANKLINE>
+
+    >>> cfg2 = YamlOptionsManager(opts_fn)
+    >>> cfg2.load()
+    >>> cfg2.configuration
+    {'last_visited_directory': '/home/adrien/photos'}
+
+    """
+    def __init__(self, opts_fn, *args, **kwargs):
+        super(YamlOptionsManager, self).__init__(*args, **kwargs)
+        self._PROTECTED_NAMES += ('load', 'store', 'opts_fn')
+        self.opts_fn = opts_fn
+
+    def load(self):
+        """Load content of *self.opts_fn*, as a YAML file, in instance.
+
+        """
+        self._data.clear()
+        if self.opts_fn is not None and os.path.exists(self.opts_fn):
+            try:
+                with open_(self.opts_fn, 'r') as fin:
+                    self._data.update(yaml.load(fin))
+            except (IOError, OSError) as e:
+                raise OptionsLoadError(
+                    _("Could not load options file: %s") % e)
+        else:
+            raise OptionsLoadError(
+                _("Could not load options: no opts_fn provided"))
+
+    def store(self):
+        """Write instance content to *self.opts_fn*, as YAML file.
+
+        """
+        if self.opts_fn is not None:
+            self._logger.debug(_("Storing config to filesystem: '%s'")
+                               % self.opts_fn)
+            dir_ = os.path.dirname(self.opts_fn)
+            if dir_:  # no need to investigate if dir_ is ''
+                if os.path.exists(self.opts_fn):
+                    if os.path.isdir(self.opts_fn):
+                        raise OptionsStoreError(
+                            _("Cannot store, as opts_fn is a directory : "
+                              "'%s'")
+                            % self.opts_fn)
+                    else:
+                        # file exists and will be overwritten: no action
+                        pass
+                elif os.path.exists(dir_):
+                    if os.path.isfile(dir_):
+                        raise OptionsStoreError(
+                            _("Cannot store, as opts_fn directory exists "
+                              "as a file: '%s'")
+                            % self.opts_fn)
+                    else:
+                        # opts_fn directory exists: no action
+                        pass
+                else:
+                    # create directory for storing the file
+                    os.makedirs(dir_)
+
+            with open_(self.opts_fn, 'w') as fout:
+                fout.write(yaml.dump(self._data))
+            self._logger.debug(_("Options file written to disk: '%s'")
+                               % self.opts_fn)
+        else:
+            raise OptionsStoreError(
+                _("Could not store config: no opts_fn provided"))
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+
+def open_(fn, *args, **kwargs):
+    """Wraps around built-in :py:func:open function on *fn*, that waits for
+    the resource to become free.
+
+    :param fn: filename to open
+
+    *ars* and *kwargs* are passed to built-in :py:func:open function.
+
+    ..Note:
+        Some keyword arguments are reserved:
+
+        * Parameter *timeout_* is used to set a maximum waiting time (in
+          seconds). Deactivated if value is 0, default value is
+          :py:const:FILE_OPEN_TIMEOUT.
+        * Parameter *_top* is used for control of warning display to user.
+
+    """
+    logger = top_logger.getChild("open_")
+    timeout_ = kwargs.pop("timeout_", FILE_OPEN_TIMEOUT)
+    _top = kwargs.pop("_top", True)  # True by default
+    if timeout_ < 0:
+        raise IOError(
+            _("Could not open file within timeout: %s") % fn)
+    try:
+        fh = open(fn, *args, **kwargs)
+    except IOError as e:
+        if _top:  # if call from user, show a warning
+            logger.warning(
+                _("File not available: '%s', waiting for it to be freed: "
+                  "%s")
+                % (os.path.basename(fn), e))
+        time.sleep(FILE_OPEN_TIME_STEP)  # then wait a little
+        # update parameters for next trial
+        kwargs["timeout_"] = (timeout_ - FILE_OPEN_TIME_STEP
+                              if timeout_ > 0 else 0)
+        kwargs["_top"] = False
+        return open_(fn, *args, **kwargs)
+    else:
+        logger.debug("File '%s' opened" % os.path.basename(fn))
+        return fh
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/photocollage/gtkgui.py
+++ b/photocollage/gtkgui.py
@@ -18,6 +18,7 @@
 import copy
 import gettext
 from io import BytesIO
+import logging
 import math
 import os.path
 import random
@@ -31,7 +32,7 @@ from six.moves import urllib  # Python 2 backward compatibility
 
 from photocollage import APP_NAME, artwork, collage, render
 from photocollage.render import PIL_SUPPORTED_EXTS as EXTS
-
+from photocollage.config import YamlOptionsManager, OptionsLoadError
 
 gettext.textdomain(APP_NAME)
 _ = gettext.gettext
@@ -39,6 +40,8 @@ _n = gettext.ngettext
 # xgettext --keyword=_n:1,2 -o po/photocollage.pot $(find . -name '*.py')
 # cp po/photocollage.pot po/fr.po
 # msgfmt -o po/fr.mo po/fr.po
+
+DEFAULT_OPTS = dict(border_w=0.01, border_c='black', out_w=800, out_h=600)
 
 
 def pil_image_to_cairo_surface(src):
@@ -126,9 +129,9 @@ class UserCollage(object):
     def __init__(self, photolist):
         self.photolist = photolist
 
-    def make_page(self, opts):
+    def make_page(self, out_h, out_w):
         # Define the output image height / width ratio
-        ratio = 1.0 * opts.out_h / opts.out_w
+        ratio = 1.0 * out_h / out_w
 
         # Compute a good number of columns. It depends on the ratio, the number
         # of images and the average ratio of these images. According to my
@@ -157,26 +160,34 @@ class PhotoCollageWindow(Gtk.Window):
     TARGET_TYPE_TEXT = 1
     TARGET_TYPE_URI = 2
 
-    def __init__(self):
+    def __init__(self, options_manager):
+        """
+
+        :param options_manager: dict-like storage for configuration data.
+            Shall also accept function `store`, that takes care of data
+            persistence at exit.
+
+        """
         super(PhotoCollageWindow, self).__init__(title=_("PhotoCollage"))
         self.history = []
         self.history_index = 0
 
-        class Options(object):
-            def __init__(self):
-                self.border_w = 0.01
-                self.border_c = "black"
-                self.out_w = 800
-                self.out_h = 600
-
-        self.opts = Options()
+        self.opts = options_manager
+        # load if options_manager file exists
+        try:
+            self.opts.load()
+        except OptionsLoadError:
+            pass
+        # set default values
+        self.opts.setdefault(**DEFAULT_OPTS)
 
         self.make_window()
 
     def make_window(self):
         self.set_border_width(10)
 
-        box_window = Gtk.Box(spacing=10, orientation=Gtk.Orientation.VERTICAL)
+        box_window = Gtk.Box(spacing=10,
+                             orientation=Gtk.Orientation.VERTICAL)
         self.add(box_window)
 
         # -----------------------
@@ -270,7 +281,8 @@ class PhotoCollageWindow(Gtk.Window):
 
             if len(photolist) > 0:
                 new_collage = UserCollage(photolist)
-                new_collage.make_page(self.opts)
+                new_collage.make_page(out_h=self.opts.out_h,
+                                      out_w=self.opts.out_w)
                 self.render_from_new_collage(new_collage)
             else:
                 self.update_tool_buttons()
@@ -310,8 +322,8 @@ class PhotoCollageWindow(Gtk.Window):
     def render_preview(self):
         collage = self.history[self.history_index]
 
-        # If the desired ratio changed in the meantime (e.g. from landscape to
-        # portrait), it needs to be re-updated
+        # If the desired ratio changed in the meantime (e.g. from landscape
+        # to portrait), it needs to be re-updated
         collage.page.target_ratio = 1.0 * self.opts.out_h / self.opts.out_w
         collage.page.adjust_cols_heights()
 
@@ -362,7 +374,8 @@ class PhotoCollageWindow(Gtk.Window):
 
     def regenerate_layout(self, button=None):
         new_collage = self.history[self.history_index].duplicate()
-        new_collage.make_page(self.opts)
+        new_collage.make_page(out_h=self.opts.out_h,
+                              out_w=self.opts.out_w)
         self.render_from_new_collage(new_collage)
 
     def select_prev_layout(self, button):
@@ -379,7 +392,7 @@ class PhotoCollageWindow(Gtk.Window):
         dialog = SettingsDialog(self)
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
-            dialog.apply_opts(self.opts)
+            self.opts.update(**dialog.retrieve_opts())
             dialog.destroy()
             if self.history:
                 self.render_preview()
@@ -449,6 +462,11 @@ class PhotoCollageWindow(Gtk.Window):
             self.history_index < len(self.history))
         self.btn_new_layout.set_sensitive(
             self.history_index < len(self.history))
+
+    def on_destroy(self, widget=None, *args):
+        """Handles window closure properly"""
+        self.opts.store()
+        Gtk.main_quit()
 
 
 class ImagePreviewArea(Gtk.DrawingArea):
@@ -585,7 +603,8 @@ class ImagePreviewArea(Gtk.DrawingArea):
             if dist <= 8 * 8:
                 self.collage.photolist.remove(cell.photo)
                 if self.collage.photolist:
-                    self.collage.make_page(self.parent.opts)
+                    self.collage.make_page(out_h=self.parent.opts.out_h,
+                                           out_w=self.parent.opts.out_w)
                     self.parent.render_from_new_collage(self.collage)
                 else:
                     self.image = None
@@ -732,11 +751,12 @@ class SettingsDialog(Gtk.Dialog):
         except ValueError:
             entry.set_text(entry.last_valid_text)
 
-    def apply_opts(self, opts):
-        opts.out_w = int(self.etr_outw.get_text() or '1')
-        opts.out_h = int(self.etr_outh.get_text() or '1')
-        opts.border_w = float(self.etr_border.get_text() or '0') / 100.0
-        opts.border_c = self.colorbutton.get_rgba().to_string()
+    def retrieve_opts(self):
+        return dict(
+            out_w=int(self.etr_outw.get_text() or '1'),
+            out_h=int(self.etr_outh.get_text() or '1'),
+            border_w=float(self.etr_border.get_text() or '0') / 100.0,
+            border_c=self.colorbutton.get_rgba().to_string())
 
 
 class ComputingDialog(Gtk.Dialog):
@@ -814,11 +834,22 @@ class PreviewFileChooserDialog(Gtk.FileChooserDialog):
 
 
 def main():
+    # set level for logging
+    logging.basicConfig(level=logging.INFO)
+
     # Enable threading. Without that, threads hang!
     GObject.threads_init()
 
-    win = PhotoCollageWindow()
-    win.connect("delete-event", Gtk.main_quit)
+    # #38: adding config file
+    if 'XDG_CONFIG_HOME' in os.environ:
+        options_dir = os.environ['XDG_CONFIG_HOME']
+    else:
+        options_dir = os.path.join(os.path.expanduser('~'), '.config')
+    options_fn = os.path.join(options_dir, 'photocollage', 'options.yml')
+    options_manager = YamlOptionsManager(opts_fn=options_fn)
+    logging.debug(_("Config filename: '%s'") % options_fn)
+    win = PhotoCollageWindow(options_manager=options_manager)
+    win.connect("delete-event", win.on_destroy)
     win.show_all()
 
     # If arguments are given, treat them as input images

--- a/photocollage/render.py
+++ b/photocollage/render.py
@@ -24,7 +24,6 @@ import PIL.ImageDraw
 
 from photocollage.collage import Photo
 
-
 QUALITY_SKEL = 0
 QUALITY_FAST = 1
 QUALITY_BEST = 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Joël Bourgault
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import os
+import unittest
+
+from photocollage.config import OptionsManager, YamlOptionsManager
+
+
+class TestOptionsManager(unittest.TestCase):
+    def setUp(self):
+        self.opts = OptionsManager()
+
+    def test_set_option(self):
+        self.opts.a = 1
+        self.assertEqual(self.opts._data, {'a': 1})
+
+    def test_set_second_option(self):
+        self.opts.a = 1
+        self.opts.b = 2
+        self.assertEqual(self.opts._data, {'a': 1, 'b': 2})
+
+    def test_setdefault(self):
+        self.opts.a = 1
+        self.opts.setdefault(a=0, b=2)
+        self.assertEqual(self.opts._data, {'a': 1, 'b': 2})
+
+    def test_update(self):
+        self.opts.a = 1
+        self.opts.update(a=0, b=2)
+        self.assertEqual(self.opts._data, {'a': 0, 'b': 2})
+
+
+class TestYamlOptionsManager(unittest.TestCase):
+    def setUp(self):
+        self.opts_fn = "opts.yml"
+        self.yaml_content = "config: {last_visited_dir: /home/adrien/photos}\n"
+        self.opts_content = {'last_visited_dir': '/home/adrien/photos'}
+
+        if os.path.exists(self.opts_fn):
+            os.remove(self.opts_fn)
+        self.opts = YamlOptionsManager(self.opts_fn)
+
+    def test_store(self):
+        self.opts.config = self.opts_content
+        self.opts.store()
+        with open(self.opts_fn) as fh:
+            opts_file_content = fh.read()
+        self.assertEqual(opts_file_content, self.yaml_content)
+
+    def test_read(self):
+        with open(self.opts_fn, 'w') as fh:
+            fh.write(self.yaml_content)
+        self.opts.load()
+        self.assertEqual(self.opts.config, self.opts_content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is linked to issue #38: remember last visited directory.

Access to configuration data can be performed by attribute or as dict
entries.

File is in YAML format, and is written automatically at exit.

I choose to make interface with other Gtk classes 'simpler', i.e. at a
lower level: these do not access Options instance directly, but directly
to parameters or to `parent` instance.

Signed-off-by: Joël Bourgault <joel.bourgault@gmail.com>